### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ QFramer
 + <a href="https://qt.qframer.com">Why QFramer?</a>  
 + <a href="https://dragondjf.github.io/qframer/Qt--QFramer.html">How to use QFramer?</a>
 
-####1.Introduction
+#### 1.Introduction
 >It's a frame based on Qt5.3, you will be more efficient with it. As an Qter,Qt give us a nice coding experience.With  user interactive experience(UE) become more and more important in modern software, deveployers should consider business and UE.So, QFramer is born. QFramer's goal is to be a mature solution which you only need to be focus on your business but UE for all Qters.
 
-####2. Support Qt version：
+#### 2. Support Qt version：
     support Qt4.8 and 5.3, 5.4 It works well with Qt4.8.6、Qt5.3.0、Qt5.3.1 and Qt5.4.0.
 
-####3. Feature
+#### 3. Feature
 + `custom titleBar`: support logo, title setiings, skin, lock, maximumed, maximumed, close custom definition.
 + `custom navgationBar`:  support add custom navagation tab.
 + `custom systemTray`: support add custom SystemTray and add context menu to SystemTray
@@ -19,17 +19,17 @@ QFramer
 + `custom skin`: support custom ui skin by qss
 + `......`
 
-####4 Download
+#### 4 Download
 + `source:` https://github.com/dragondjf/QCFramer/archive/develop.zip
 + `Realease`: http://pan.baidu.com/s/1qWI2lXi
 
-####5: Snapshot
+#### 5: Snapshot
 ![6](doc/v0.25_1.png)
 ![7](doc/v0.25_2.png)
 ![8](doc/v0.25_3.png)
 ![9](doc/v0.25_4.png)
 
-####6.Contact
+#### 6.Contact
 + `Email:` ding465398889@163.com or dragondjf@gmail.com or 465398889@qq.com
 + `Github:` https://github.com/dragondjf/QFramer
 

--- a/README_En.md
+++ b/README_En.md
@@ -1,12 +1,12 @@
 QFramer 
 ============
-####1.Introduction
+#### 1.Introduction
 >It's a frame based on Qt5.3, you will be more efficient with it. As an Qter,Qt give us a nice coding experience.With  user interactive experience(UE) become more and more important in modern software, deveployers should consider business and UE.So, QFramer is born. QFramer's goal is to be a mature solution which you only need to be focus on your business but UE for all Qters.
 
-####2. Support Qt version：
+#### 2. Support Qt version：
     support Qt4.8 and 5.3, It works well with Qt4.8.6、Qt5.3.0 and Qt5.3.1.
 
-####3. Feature
+#### 3. Feature
 + `custom titleBar`: support logo, title setiings, skin, lock, maximumed, maximumed, close custom definition.
 + `custom navgationBar`:  support add custom navagation tab.
 + `custom SystemTray`: support add custom SystemTray and add context menu to SystemTray
@@ -16,17 +16,17 @@ QFramer
 + `custom skin`: support custom ui skin by qss
 + `......`
 
-####4 Download
+#### 4 Download
 + `source:` https://github.com/dragondjf/QCFramer/archive/develop.zip 
 + `Realease`: http://pan.baidu.com/s/1qWI2lXi
 
-####5: Snapshot
+#### 5: Snapshot
 ![6](doc/v0.25_1.png)
 ![7](doc/v0.25_2.png)
 ![8](doc/v0.25_3.png)
 ![9](doc/v0.25_4.png)
 
-####6.Contact
+#### 6.Contact
 + `Email:` ding465398889@163.com or dragondjf@gmail.com or 465398889@qq.com
 + `Github:` https://github.com/dragondjf/QCFramer
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,6 +1,6 @@
 QFramer 基于Qt5的快速开发框架
 ============
-####1.Introduction
+#### 1.Introduction
 
 作为一名Qter，我们都知道Qt的强大带给我们nice的编码体验。伴随着用户交互体验越来越受到重视，移动端UI交互体验的冲击，PC端UI交互体验的提升近在眼前。Qt基于c++的跨平台开发框架，已经帮我们做了很多繁琐和苦累的工作，提供一套优美的api和多种开发模式： 
 1. `QtWidgets + qss`    
@@ -10,9 +10,9 @@ QFramer 基于Qt5的快速开发框架
 对于软件大小没有严格限制的软件而言，在qt5里面可以完美结合三种开发方式，极大提高生产效率，但存在技术门槛较高，坑也较多，资料相对较少的缺陷。为此，QFramer应运而生，采用基于QtWidgets + qss的开发模式，自定义核心控件，提供一套完整风格的自定义控件，使开发者能够将更多的精力专注于业务逻辑，无需过于担心UI体验。
 
 QFramer必将不负您的期望。
-####2. 版本支持：
+#### 2. 版本支持：
     支持版本Qt4.8和5.3，目前已经在Qt4.8.6、Qt5.3.0、Qt5.3.1上做过验证。
-####3. 特性
+#### 3. 特性
 + `自定义标题栏`: 支持自定义设置menu,皮肤切换menu,锁屏解屏按钮，最小化最大化关闭按钮
 + `自定义top导航tab`:  支持随意添加导航条，只需要关联上相应的功能页面，即可根据tab切换页面
 + `自定义系统托盘`: 支持系统托盘关联自定义菜单
@@ -23,17 +23,17 @@ QFramer必将不负您的期望。
 + `内置QCustomPlot`: 高效2d绘图库
 + 更多的特性等你来挖掘......
 
-####4 下载
+#### 4 下载
 + `source:` https://github.com/dragondjf/QCFramer/archive/develop.zip
 + `windows realease`: http://pan.baidu.com/s/1qWI2lXi
 
-####5: 快照
+#### 5: 快照
 ![6](doc/v0.25_1.png)
 ![7](doc/v0.25_2.png)
 ![8](doc/v0.25_3.png)
 ![9](doc/v0.25_4.png)
 
-####6.Contact
+#### 6.Contact
 + `Email:` ding465398889@163.com or dragondjf@gmail.com or 465398889@qq.com
 + `Github:` https://github.com/dragondjf/QCFramer
 

--- a/doc/QFramer help.md
+++ b/doc/QFramer help.md
@@ -1,6 +1,6 @@
 QFramer help 
 ===============================================
-#####1.How to use QFramer in your project?
+##### 1.How to use QFramer in your project?
 + 1.**`New`** a Qt project in your Qt Creater IDE;
 + 2.**`Copy`** directory **【QFramer】** to your project folder, add `include(./QFramer/QFramer.pri)` in your **.pro** file
 
@@ -8,7 +8,7 @@ QFramer help
 
         #include "QFramer/fcenterwindow.h"
 
-#####2. How to use QFramer in your code?
+##### 2. How to use QFramer in your code?
 
 
 + 1. custom your mainwindow inherited by `FMainWindow`


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
